### PR TITLE
Fix for cannot instantiate 'PosixPath' on your system on Windows

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,12 +3,17 @@ import tyro
 import subprocess
 import gradio as gr
 import os.path as osp
+import platform
 from src.utils.helper import load_description
 from src.gradio_pipeline import GradioPipeline, GradioPipelineAnimal
 from src.config.crop_config import CropConfig
 from src.config.argument_config import ArgumentConfig
 from src.config.inference_config import InferenceConfig
 
+if platform.system() == "Windows":
+    import pathlib
+    temp = pathlib.PosixPath
+    pathlib.PosixPath = pathlib.WindowsPath
 
 def partial_fields(target_class, kwargs):
     return target_class(**{k: v for k, v in kwargs.items() if hasattr(target_class, k)})

--- a/inference.py
+++ b/inference.py
@@ -3,9 +3,15 @@ import os
 import os.path as osp
 import tyro
 import subprocess
+import platform
 from src.config.argument_config import ArgumentConfig
 from src.config.inference_config import InferenceConfig
 from src.config.crop_config import CropConfig
+
+if platform.system() == "Windows":
+    import pathlib
+    temp = pathlib.PosixPath
+    pathlib.PosixPath = pathlib.WindowsPath
 
 def partial_fields(target_class, kwargs):
     return target_class(**{k: v for k, v in kwargs.items() if hasattr(target_class, k)})


### PR DESCRIPTION
This address the following issue on Windows
NotImplementedError: cannot instantiate 'PosixPath' on your system